### PR TITLE
BUGFIX: some keys could not be pressed at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@
 
 # Add precompiled .hex
 !precompiled/*.hex
+
+# ignore eclipse project files
+.cproject
+.metadata/
+.project
+.settings/
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+DIRS=redox-w-receiver-basic/custom/armgcc redox-w-keyboard-basic/custom/armgcc
+
+all::
+	make -C redox-w-receiver-basic/custom/armgcc; \
+	make -C redox-w-keyboard-basic/custom/armgcc keyboard_side=left; \
+	make -C redox-w-keyboard-basic/custom/armgcc keyboard_side=right; 
+
+clean::
+	make -C redox-w-receiver-basic/custom/armgcc clean; \
+	make -C redox-w-keyboard-basic/custom/armgcc clean; \
+	make -C redox-w-keyboard-basic/custom/armgcc clean; 

--- a/README.md
+++ b/README.md
@@ -31,21 +31,26 @@ cd nRF5_SDK_11
 ## Toolchain set-up
 
 A cofiguration file that came with the SDK needs to be changed. Assuming you installed gcc-arm with apt, the compiler root path needs to be changed in /components/toolchain/gcc/Makefile.posix, the line:
+
 ```
 GNU_INSTALL_ROOT := /usr/local/gcc-arm-none-eabi-4_9-2015q1
 ```
+
 Replaced with:
+
 ```
 GNU_INSTALL_ROOT := /usr/
 ```
 
 ## Clone repository
 Inside nRF5_SDK_11/
+
 ```
 git clone https://github.com/mattdibi/redox-w-firmware
 ```
 
 ## Install udev rules
+
 ```
 sudo cp redox-w-firmware/49-stlinkv2.rules /etc/udev/rules.d/
 ```
@@ -61,10 +66,12 @@ The programming header on the side of the keyboard:
 It's best to remove the battery during long sessions of debugging, as charging non-rechargeable lithium batteries isn't recommended.
 
 Launch a debugging session with:
+
 ```
 openocd -s /usr/local/Cellar/open-ocd/0.8.0/share/openocd/scripts/ -f interface/stlink-v2.cfg -f target/nrf51_stlink.tcl
 ```
 Should give you an output ending in:
+
 ```
 Info : nrf51.cpu: hardware has 4 breakpoints, 2 watchpoints
 ```
@@ -73,11 +80,13 @@ Otherwise you likely have a loose or wrong wire.
 
 ## Manual programming
 From the factory, these chips need to be erased:
+
 ```
 echo reset halt | telnet localhost 4444
 echo nrf51 mass_erase | telnet localhost 4444
 ```
 From there, the precompiled binaries can be loaded:
+
 ```
 echo reset halt | telnet localhost 4444
 echo flash write_image `readlink -f precompiled-basic-left.hex` | telnet localhost 4444
@@ -86,8 +95,8 @@ echo reset | telnet localhost 4444
 
 ## Automatic make and programming scripts
 To use the automatic build scripts:
-```
-cd redox-w-firmware/redox-w-keyboard-basic
-./program.sh
-```
+* keyboard-left: `./redox-w-keyboard-basic/program_left.sh`
+* keyboard-right: `./redox-w-keyboard-basic/program_right.sh`
+* receiver: `./redox-w-receiver-basic/program.sh`
+
 An openocd session should be running in another terminal, as this script sends commands to it.

--- a/redox-w-keyboard-basic/custom/armgcc/Makefile
+++ b/redox-w-keyboard-basic/custom/armgcc/Makefile
@@ -91,6 +91,15 @@ CFLAGS += -mfloat-abi=soft
 # keep every function in separate section. This will allow linker to dump unused functions
 CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
 CFLAGS += -fno-builtin --short-enums
+
+ifeq ("$(keyboard_side)","left") 
+CFLAGS += -DCOMPILE_LEFT 
+endif
+
+ifeq ("$(keyboard_side)","right") 
+CFLAGS += -DCOMPILE_RIGHT 
+endif
+
 # keep every function in separate section. This will allow linker to dump unused functions
 LDFLAGS += -Xlinker -Map=$(LISTING_DIRECTORY)/$(OUTPUT_FILENAME).map
 LDFLAGS += -mthumb -mabi=aapcs -L $(TEMPLATE_PATH) -T$(LINKER_SCRIPT)
@@ -135,7 +144,7 @@ vpath %.s $(ASM_PATHS)
 
 OBJECTS = $(C_OBJECTS) $(ASM_OBJECTS)
 
-nrf51822_xxac: OUTPUT_FILENAME := nrf51822_xxac
+nrf51822_xxac: OUTPUT_FILENAME := "nrf51822_xxac-keyboard-$(keyboard_side)"
 nrf51822_xxac: LINKER_SCRIPT=gzll_gcc_nrf51.ld
 
 nrf51822_xxac: $(BUILD_DIRECTORIES) $(OBJECTS)

--- a/redox-w-keyboard-basic/main.c
+++ b/redox-w-keyboard-basic/main.c
@@ -9,6 +9,8 @@
 #include "nrf_delay.h"
 #include "nrf_drv_clock.h"
 #include "nrf_drv_rtc.h"
+#include "nrf51_bitfields.h"
+#include "nrf51.h"
 
 
 /*****************************************************************************/

--- a/redox-w-keyboard-basic/main.c
+++ b/redox-w-keyboard-basic/main.c
@@ -1,6 +1,6 @@
-
-// #define COMPILE_RIGHT
-#define COMPILE_LEFT
+/*
+ * Either COMPILE_RIGHT or COMPILE_LEFT has to be defined from the make call to allow proper functionality
+ */
 
 #include "redox-w.h"
 #include "nrf_drv_config.h"

--- a/redox-w-keyboard-basic/main.c
+++ b/redox-w-keyboard-basic/main.c
@@ -62,7 +62,7 @@ static void gpio_config(void)
 static void read_keys(void)
 {
     unsigned short c;
-    uint32_t input = 0;
+    volatile uint32_t input = 0;
     uint8_t row_stat[5] = {0, 0, 0, 0, 0};
 
     // scan matrix by columns

--- a/redox-w-keyboard-basic/program_left.sh
+++ b/redox-w-keyboard-basic/program_left.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
 echo '=============================== MAKING ================================'
 cd custom/armgcc
-make
+make keyboard_side=left
 if [[ $? -ne 0 ]] ; then
     exit 0
 fi
 sleep 0.1
-HEX=`readlink -f _build/nrf51822_xxac.hex`
+HEX=`readlink -f "$SCRIPT_DIR/_build/nrf51822_xxac-keyboard-left.hex"`
 du -b $HEX
 
 echo
@@ -15,7 +17,7 @@ echo '============================= PROGRAMMING ============================='
 	echo "reset halt";
 	sleep 0.1;
 	echo "flash write_image erase" $HEX;
-	sleep 10;
+	sleep 11;
 	echo "reset";
 	sleep 0.1;
 	exit;

--- a/redox-w-keyboard-basic/program_right.sh
+++ b/redox-w-keyboard-basic/program_right.sh
@@ -3,12 +3,12 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 echo '=============================== MAKING ================================'
 cd custom/armgcc
-make
+make keyboard_side=right
 if [[ $? -ne 0 ]] ; then
     exit 0
 fi
 sleep 0.1
-HEX=`readlink -f "$SCRIPT_DIR/_build/nrf51822_xxac-receiver.hex"`
+HEX=`readlink -f "$SCRIPT_DIR/_build/nrf51822_xxac-keyboard-right.hex"`
 du -b $HEX
 
 echo

--- a/redox-w-receiver-basic/custom/armgcc/Makefile
+++ b/redox-w-receiver-basic/custom/armgcc/Makefile
@@ -139,7 +139,7 @@ vpath %.s $(ASM_PATHS)
 
 OBJECTS = $(C_OBJECTS) $(ASM_OBJECTS)
 
-nrf51822_xxac: OUTPUT_FILENAME := nrf51822_xxac
+nrf51822_xxac: OUTPUT_FILENAME := nrf51822_xxac-receiver
 nrf51822_xxac: LINKER_SCRIPT=uart_gcc_nrf51.ld
 
 nrf51822_xxac: $(BUILD_DIRECTORIES) $(OBJECTS)


### PR DESCRIPTION
This fixes an issue where some keys prevented other keys to be pressed
when they are pressed. To fix this, the variable used to read the GPIOs
is marked as volatile. This bug maybe only occurs with arm-none-eabi-gcc
version 9.1.0.