### PR TITLE
Slow the data rate and configure an interleaved channel table 

### DIFF
--- a/redox-w-keyboard-basic/main.c
+++ b/redox-w-keyboard-basic/main.c
@@ -40,6 +40,13 @@ static volatile bool debouncing = false;
 // Debug helper variables
 static volatile bool init_ok, enable_ok, push_ok, pop_ok, tx_success;
 
+#ifdef COMPILE_LEFT
+static uint8_t channel_table[3]={4, 42, 77};
+#endif
+#ifdef COMPILE_RIGHT
+static uint8_t channel_table[3]={25, 63, 33};
+#endif
+
 // Setup switch pins with pullups
 static void gpio_config(void)
 {
@@ -225,6 +232,10 @@ int main()
 
     // Attempt sending every packet up to 100 times
     nrf_gzll_set_max_tx_attempts(100);
+    nrf_gzll_set_timeslots_per_channel(4);
+    nrf_gzll_set_channel_table(channel_table,3);
+    nrf_gzll_set_datarate(NRF_GZLL_DATARATE_1MBIT);
+    nrf_gzll_set_timeslot_period(900);
 
     // Addressing
     nrf_gzll_set_base_address_0(0x01020304);

--- a/redox-w-receiver-basic/main.c
+++ b/redox-w-receiver-basic/main.c
@@ -53,6 +53,7 @@ uint32_t left_active = 0;
 uint32_t right_active = 0;
 uint8_t c;
 
+static uint8_t channel_table[6]={4, 25, 42, 63, 77, 33};
 
 void uart_error_handle(app_uart_evt_t * p_event)
 {
@@ -92,6 +93,9 @@ int main(void)
 
     // Initialize Gazell
     nrf_gzll_init(NRF_GZLL_MODE_HOST);
+    nrf_gzll_set_channel_table(channel_table,6);
+    nrf_gzll_set_datarate(NRF_GZLL_DATARATE_1MBIT);
+    nrf_gzll_set_timeslot_period(900);
 
     // Addressing
     nrf_gzll_set_base_address_0(0x01020304);


### PR DESCRIPTION
Created a Channel Table on the Receiver with 6 channels and then used 3 channels on each transmitter, alternating the list of channels between the 2 transmitters.  This now lines up with the recommended method as documented by Nordic.

I've also dropped the Data Rate and tweaked the appropriate timeslot settings to match in the hopes that the range/connection stability might be improved but I'm not sure how much difference it makes ... though it might now be possible to decrease the TX power to extend battery life without impacting performance. 