### PR TITLE
Fix toplevel makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
-DIRS=redox-w-receiver-basic/custom/armgcc redox-w-keyboard-basic/custom/armgcc
 
-all::
-	make -C redox-w-receiver-basic/custom/armgcc; \
-	make -C redox-w-keyboard-basic/custom/armgcc keyboard_side=left; \
-	make -C redox-w-keyboard-basic/custom/armgcc keyboard_side=right; 
+all:
+	make -C redox-w-receiver-basic/custom/armgcc
+	make -C redox-w-keyboard-basic/custom/armgcc
 
-clean::
-	make -C redox-w-receiver-basic/custom/armgcc clean; \
-	make -C redox-w-keyboard-basic/custom/armgcc clean; \
-	make -C redox-w-keyboard-basic/custom/armgcc clean; 
+clean:
+	make -C redox-w-receiver-basic/custom/armgcc clean
+	make -C redox-w-keyboard-basic/custom/armgcc clean


### PR DESCRIPTION
This change aligns the toplevel makefile with the recent changes to
the receiver and keyboard makefiles.

Signed-off-by: Nikos Nikoleris <nikos.nikoleris@gmail.com>